### PR TITLE
Add yara.Match as a Python dict for additional context

### DIFF
--- a/modules/Signature/YaraScan.py
+++ b/modules/Signature/YaraScan.py
@@ -6,6 +6,7 @@ import os
 import sys
 import time
 from common import parseDir
+from operator import itemgetter
 
 __authors__ = "Nick Beede, Drew Bonasera"
 __license__ = "MPL 2.0"
@@ -78,8 +79,15 @@ def scan(filelist, conf=DEFAULTCONF):
             hlist = []
             for h in hit:
                 if not set(h.tags).intersection(set(conf["ignore-tags"])):
-                    hlist.append(str(h))
-            hlist.sort()
+                    hit_dict = {
+                        'meta'      : h.meta,
+                        'namespace' : h.namespace,
+                        'rule'      : h.rule,
+                        'strings'   : h.strings,
+                        'tags'      : h.tags,
+                    }
+                    hlist.append(hit_dict)
+            hlist = sorted(hlist, key=itemgetter('rule'))
             matches.append((m, hlist))
             
     metadata = {}


### PR DESCRIPTION
Here's my initial crack at adding some more details from the yarascan results. This is all the information available form the yara.Match object. 

If we want the full text of the rule, we should talk about a sane way to do it. Note: these results include the `namespace`, which will be the filepath in our case. If the analyst has access to wherever the rules are hosted, they could find a rule pretty easily; however, it is an extra step.